### PR TITLE
Add JSON serialization for Routine and Task

### DIFF
--- a/lib/models/routine.dart
+++ b/lib/models/routine.dart
@@ -70,6 +70,31 @@ class Routine {
       categories.hashCode ^
       tasks.hashCode;
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'description': description,
+      'categories': categories,
+      'tasks': tasks.map((task) => task.toJson()).toList(),
+      'isPinned': isPinned,
+    };
+  }
+
+  factory Routine.fromJson(Map<String, dynamic> json) {
+    return Routine(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String? ?? '',
+      categories:
+          (json['categories'] as List<dynamic>? ?? []).cast<String>(),
+      tasks: (json['tasks'] as List<dynamic>? ?? [])
+          .map((e) => Task.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
+      isPinned: json['isPinned'] as bool? ?? false,
+    );
+  }
 }
 
 @HiveType(typeId: 1)
@@ -141,4 +166,26 @@ class Task {
       notes.hashCode ^
       order.hashCode;
   }
-} 
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+      'category': category,
+      'photoRequired': photoRequired,
+      'notes': notes,
+      'order': order,
+    };
+  }
+
+  factory Task.fromJson(Map<String, dynamic> json) {
+    return Task(
+      id: json['id'] as String,
+      label: json['label'] as String,
+      category: json['category'] as String?,
+      photoRequired: json['photoRequired'] as bool? ?? false,
+      notes: json['notes'] as String?,
+      order: json['order'] as int,
+    );
+  }
+}

--- a/test/models/routine_test.dart
+++ b/test/models/routine_test.dart
@@ -33,6 +33,14 @@ void main() {
 
     test('JSON serialization', () {
       final json = task.toJson();
+      expect(json, {
+        'id': '1',
+        'label': 'Test Task',
+        'category': 'Morning',
+        'photoRequired': true,
+        'notes': 'Some notes',
+        'order': 1,
+      });
       final fromJson = Task.fromJson(json);
       expect(fromJson, equals(task));
     });
@@ -75,6 +83,23 @@ void main() {
 
     test('JSON serialization', () {
       final json = routine.toJson();
+      expect(json, {
+        'id': 'r1',
+        'title': 'Morning Routine',
+        'description': 'Start your day right',
+        'categories': ['Morning'],
+        'tasks': [
+          {
+            'id': '1',
+            'label': 'Test Task',
+            'category': 'Morning',
+            'photoRequired': true,
+            'notes': 'Some notes',
+            'order': 1,
+          }
+        ],
+        'isPinned': false,
+      });
       final fromJson = Routine.fromJson(json);
       expect(fromJson, equals(routine));
     });


### PR DESCRIPTION
## Summary
- add `toJson`/`fromJson` to `Routine` and `Task`
- verify expected serialization in unit tests

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c72ad8ac08331a2a1a4290113378b